### PR TITLE
fix(security): Use environment variables for database credentials

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,6 @@
-spring.datasource.url=jdbc:postgresql://db.yxenzarqnfdmqmdqnvsz.supabase.co:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=sbGupyfy@
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Removes hardcoded database credentials from the application.properties file to prevent sensitive information from being exposed in the source code and Git history.

This change replaces the static values with placeholders that read from environment variables (DB_URL, DB_USERNAME, DB_PASSWORD), following security best practices.

Closes #46